### PR TITLE
Enable hive partitioning based on table metadata

### DIFF
--- a/lib/deltalake/table.rb
+++ b/lib/deltalake/table.rb
@@ -204,7 +204,12 @@ module DeltaLake
           "DELTA_DYNAMO_TABLE_NAME"
         ]
         storage_options = @storage_options&.reject { |k, _| delta_keys.include?(k.to_s.upcase) }
-        lf = Polars.scan_parquet(sources, storage_options: storage_options, rechunk: rechunk)
+        lf = Polars.scan_parquet(
+          sources,
+          hive_partitioning: !metadata.partition_columns.empty?,
+          storage_options: storage_options,
+          rechunk: rechunk
+        )
 
         if columns
           # by_name requires polars-df > 0.15.0


### PR DESCRIPTION
Fix: https://github.com/ankane/delta-ruby/issues/2

```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"

  gem "deltalake-rb", path: "../delta-ruby"
  gem "polars-df"
end

table_name = "/tmp/deltadb"

df = Polars::DataFrame.new({
  "id" => (1..10).to_a,
  "type" => 10.times.map { ["foo", "bar"].sample },
  "value" => (101..110).to_a,
})

DeltaLake.write(table_name, df, partition_by: ["type"], mode: "append")

table = DeltaLake::Table.new(table_name)
pp table.to_polars.filter(Polars.col("type") == "foo")
```

Output:
```
shape: (5, 3)
┌─────┬───────┬──────┐
│ id  ┆ value ┆ type │
│ --- ┆ ---   ┆ ---  │
│ i64 ┆ i64   ┆ str  │
╞═════╪═══════╪══════╡
│ 3   ┆ 103   ┆ foo  │
│ 4   ┆ 104   ┆ foo  │
│ 5   ┆ 105   ┆ foo  │
│ 8   ┆ 108   ┆ foo  │
│ 10  ┆ 110   ┆ foo  │
└─────┴───────┴──────┘
```