### PR TITLE
Make S3, Azure, and GCS storage backends optional at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Delta Lake](https://delta.io/) for Ruby
 
-Supports local files and Amazon S3
+Supports local files and cloud storage (Amazon S3, Azure Blob Storage, Google Cloud Storage)
 
 [![Build Status](https://github.com/ankane/delta-ruby/actions/workflows/build.yml/badge.svg)](https://github.com/ankane/delta-ruby/actions)
 
@@ -15,6 +15,34 @@ gem "deltalake-rb"
 ```
 
 It can take 5-10 minutes to compile the gem.
+
+Cloud storage support is optional. Enable the backends you need at install time:
+
+```sh
+# Amazon S3
+gem install deltalake-rb -- --enable-s3
+
+# Azure Blob Storage
+gem install deltalake-rb -- --enable-azure
+
+# Google Cloud Storage
+gem install deltalake-rb -- --enable-gcs
+
+# Multiple backends
+gem install deltalake-rb -- --enable-s3 --enable-azure --enable-gcs
+```
+
+Or via environment variables:
+
+```sh
+DELTALAKE_S3=1 DELTALAKE_AZURE=1 DELTALAKE_GCS=1 gem install deltalake-rb
+```
+
+With Bundler, use `bundle config`:
+
+```sh
+bundle config build.deltalake-rb "--enable-s3"
+```
 
 ## Getting Started
 

--- a/ext/deltalake/Cargo.toml
+++ b/ext/deltalake/Cargo.toml
@@ -10,12 +10,17 @@ publish = false
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+azure = ["deltalake/azure"]
+gcs = ["deltalake/gcs"]
+s3 = ["deltalake/s3"]
+
 [dependencies]
 arrow = { version = "55", features = ["ffi"] }
 arrow-schema = { version = "55", features = ["serde"] }
 chrono = "0.4"
 delta_kernel = "=0.10.0"
-deltalake = { version = "=0.26.0", features = ["azure", "datafusion", "gcs", "s3"] }
+deltalake = { version = "=0.26.0", features = ["datafusion"] }
 futures = "0.3"
 magnus = "0.7"
 num_cpus = "1"

--- a/ext/deltalake/extconf.rb
+++ b/ext/deltalake/extconf.rb
@@ -1,4 +1,10 @@
 require "mkmf"
 require "rb_sys/mkmf"
 
-create_rust_makefile("deltalake/deltalake")
+create_rust_makefile("deltalake/deltalake") do |r|
+  features = []
+  features << "s3" if enable_config("s3") || ENV["DELTALAKE_S3"]
+  features << "azure" if enable_config("azure") || ENV["DELTALAKE_AZURE"]
+  features << "gcs" if enable_config("gcs") || ENV["DELTALAKE_GCS"]
+  r.features = features
+end

--- a/ext/deltalake/src/lib.rs
+++ b/ext/deltalake/src/lib.rs
@@ -1269,8 +1269,11 @@ impl ArrowArrayStream {
 
 #[magnus::init]
 fn init(ruby: &Ruby) -> RbResult<()> {
+    #[cfg(feature = "s3")]
     deltalake::aws::register_handlers(None);
+    #[cfg(feature = "azure")]
     deltalake::azure::register_handlers(None);
+    #[cfg(feature = "gcs")]
     deltalake::gcp::register_handlers(None);
 
     let module = ruby.define_module("DeltaLake")?;


### PR DESCRIPTION
## Summary

- Cloud storage backends (S3, Azure, GCS) are now opt-in rather than always compiled in
- Reduces compile time and binary size for users who only need local storage
- Adds `[features]` section to `ext/deltalake/Cargo.toml` mapping each backend to the corresponding `deltalake` crate feature
- Gates `register_handlers` calls in `src/lib.rs` behind `#[cfg(feature = "...")]`
- Updates `extconf.rb` to read `--enable-s3/azure/gcs` configure flags or `DELTALAKE_S3/AZURE/GCS` env vars

## Usage

```sh
# Single backend
gem install deltalake-rb -- --enable-s3

# Multiple backends
gem install deltalake-rb -- --enable-s3 --enable-azure --enable-gcs

# Via env vars
DELTALAKE_S3=1 gem install deltalake-rb

# With Bundler
bundle config build.deltalake-rb "--enable-s3"
```

## Test plan

- [x] Compiled without any backend (local storage only)
- [x] Compiled with GCS only (`DELTALAKE_GCS=1`)
- [x] Compiled with S3 only
- [x] Compiled with all three backends